### PR TITLE
Update input types and add missing inputs

### DIFF
--- a/typings/Azure/webapps-deploy/v2/action-types.yml
+++ b/typings/Azure/webapps-deploy/v2/action-types.yml
@@ -17,6 +17,9 @@ inputs:
     type: string
   startup-command:
     type: string
+  resource-group-name:
+    type: string
+
 outputs:
   webapp-url:
     type: string

--- a/typings/Azure/webapps-deploy/v3/action-types.yml
+++ b/typings/Azure/webapps-deploy/v3/action-types.yml
@@ -17,6 +17,22 @@ inputs:
     type: string
   startup-command:
     type: string
+  resource-group-name:
+    type: string
+  type:
+    type: enum
+    allowed-values:
+      - JAR
+      - WAR
+      - EAR
+      - ZIP
+      - Static
+  target-path:
+    type: string
+  clean:
+    type: boolean
+  restart:
+    type: boolean
 outputs:
   webapp-url:
     type: string

--- a/typings/Wandalen/wretry.action/v3/action-types.yml
+++ b/typings/Wandalen/wretry.action/v3/action-types.yml
@@ -30,6 +30,9 @@ inputs:
   github_token:
     type: string
 
+  pre_retry_command:
+    type: string
+
 outputs:
   outputs:
     type: string

--- a/typings/Wandalen/wretry.action/v3/main/action-types.yml
+++ b/typings/Wandalen/wretry.action/v3/main/action-types.yml
@@ -30,6 +30,9 @@ inputs:
   github_token:
     type: string
 
+  pre_retry_command:
+    type: string
+
 outputs:
   outputs:
     type: string

--- a/typings/Wandalen/wretry.action/v3/post/action-types.yml
+++ b/typings/Wandalen/wretry.action/v3/post/action-types.yml
@@ -30,6 +30,9 @@ inputs:
   github_token:
     type: string
 
+  pre_retry_command:
+    type: string
+
 outputs:
   outputs:
     type: string

--- a/typings/Wandalen/wretry.action/v3/pre/action-types.yml
+++ b/typings/Wandalen/wretry.action/v3/pre/action-types.yml
@@ -30,6 +30,9 @@ inputs:
   github_token:
     type: string
 
+  pre_retry_command:
+    type: string
+
 outputs:
   outputs:
     type: string

--- a/typings/actions/checkout/v4/action-types.yml
+++ b/typings/actions/checkout/v4/action-types.yml
@@ -38,6 +38,10 @@ inputs:
     type: boolean
   fetch-tags:
     type: boolean
+  ssh-user:
+    type: string
+  filter:
+    type: string
 
 outputs:
   ref:

--- a/typings/actions/github-script/v7/action-types.yml
+++ b/typings/actions/github-script/v7/action-types.yml
@@ -26,6 +26,9 @@ inputs:
     separator: ','
     list-item:
       type: integer
+  base-url:
+    type: string
+
 outputs:
   result:
     type: string

--- a/typings/actions/setup-dotnet/v3/action-types.yml
+++ b/typings/actions/setup-dotnet/v3/action-types.yml
@@ -22,7 +22,10 @@ inputs:
   cache:
     type: boolean
   cache-dependency-path:
-    type: string
+    type: list
+    separator: "\n"
+    list-item:
+      type: string
 
 outputs:
   cache-hit:

--- a/typings/actions/setup-dotnet/v3/action-types.yml
+++ b/typings/actions/setup-dotnet/v3/action-types.yml
@@ -21,6 +21,9 @@ inputs:
     type: string
   cache:
     type: boolean
+  cache-dependency-path:
+    type: string
+
 outputs:
   cache-hit:
     type: boolean

--- a/typings/actions/setup-dotnet/v4/action-types.yml
+++ b/typings/actions/setup-dotnet/v4/action-types.yml
@@ -22,7 +22,10 @@ inputs:
   cache:
     type: boolean
   cache-dependency-path:
-    type: string
+    type: list
+    separator: "\n"
+    list-item:
+      type: string
 
 outputs:
   cache-hit:

--- a/typings/actions/setup-dotnet/v4/action-types.yml
+++ b/typings/actions/setup-dotnet/v4/action-types.yml
@@ -21,6 +21,9 @@ inputs:
     type: string
   cache:
     type: boolean
+  cache-dependency-path:
+    type: string
+
 outputs:
   cache-hit:
     type: boolean

--- a/typings/actions/setup-java/v3/action-types.yml
+++ b/typings/actions/setup-java/v3/action-types.yml
@@ -55,6 +55,9 @@ inputs:
     type: string
   mvn-toolchain-vendor:
     type: string
+  java-version-file:
+    type: string
+
 outputs:
   distribution: *distribution
   version:

--- a/typings/actions/setup-java/v4/action-types.yml
+++ b/typings/actions/setup-java/v4/action-types.yml
@@ -57,6 +57,9 @@ inputs:
     type: string
   cache-dependency-path:
     type: string
+  java-version-file:
+    type: string
+
 outputs:
   distribution: *distribution
   version:

--- a/typings/actions/upload-artifact/v3/action-types.yml
+++ b/typings/actions/upload-artifact/v3/action-types.yml
@@ -19,3 +19,5 @@ inputs:
     name: RetentionPeriod
     named-values:
       Default: 0
+  include-hidden-files:
+    type: boolean

--- a/typings/actions/upload-artifact/v4/action-types.yml
+++ b/typings/actions/upload-artifact/v4/action-types.yml
@@ -29,6 +29,8 @@ inputs:
       BestCompression: 9
   overwrite:
     type: boolean
+  include-hidden-files:
+    type: boolean
 outputs:
   artifact-id:
     type: integer

--- a/typings/aws-actions/amazon-ecr-login/v1/action-types.yml
+++ b/typings/aws-actions/amazon-ecr-login/v1/action-types.yml
@@ -14,6 +14,9 @@ inputs:
     allowed-values:
     - private
     - public
+  http-proxy:
+    type: string
+
 outputs:
   registry:
     type: string

--- a/typings/aws-actions/amazon-ecr-login/v2/action-types.yml
+++ b/typings/aws-actions/amazon-ecr-login/v2/action-types.yml
@@ -14,6 +14,9 @@ inputs:
     allowed-values:
     - private
     - public
+  http-proxy:
+    type: string
+
 outputs:
   registry:
     type: string

--- a/typings/aws-actions/amazon-ecs-render-task-definition/v1/action-types.yml
+++ b/typings/aws-actions/amazon-ecs-render-task-definition/v1/action-types.yml
@@ -28,6 +28,20 @@ inputs:
     separator: "\n"
     list-item:
       type: string
+  task-definition-arn:
+    type: string
+  task-definition-family:
+    type: string
+  task-definition-revision:
+    type: string
+  command:
+    type: string
+  secrets:
+    type: list
+    separator: "\n"
+    list-item:
+      type: string
+
 outputs:
   task-definition:
     type: string

--- a/typings/aws-actions/configure-aws-credentials/v3/action-types.yml
+++ b/typings/aws-actions/configure-aws-credentials/v3/action-types.yml
@@ -41,6 +41,11 @@ inputs:
     type: integer
   special-characters-workaround:
     type: boolean
+  unset-current-credentials:
+    type: boolean
+  disable-retry:
+    type: boolean
+
 outputs:
   aws-account-id:
     type: string

--- a/typings/aws-actions/configure-aws-credentials/v4/action-types.yml
+++ b/typings/aws-actions/configure-aws-credentials/v4/action-types.yml
@@ -41,6 +41,11 @@ inputs:
     type: integer
   special-characters-workaround:
     type: boolean
+  unset-current-credentials:
+    type: boolean
+  disable-retry:
+    type: boolean
+
 outputs:
   aws-account-id:
     type: string

--- a/typings/axel-op/googlejavaformat-action/v3/action-types.yml
+++ b/typings/axel-op/googlejavaformat-action/v3/action-types.yml
@@ -14,3 +14,9 @@ inputs:
     type: string
   commit-message:
     type: string
+  skipCommit:
+    type: boolean
+  commitMessage:
+    type: string
+  githubToken:
+    type: string

--- a/typings/bahmutov/npm-install/v1/action-types.yml
+++ b/typings/bahmutov/npm-install/v1/action-types.yml
@@ -8,3 +8,5 @@ inputs:
     type: boolean
   install-command:
     type: string
+  cache-key-prefix:
+    type: string

--- a/typings/codecov/codecov-action/v3/action-types.yml
+++ b/typings/codecov/codecov-action/v3/action-types.yml
@@ -103,4 +103,7 @@ inputs:
   working-directory:
     type: string
   xtra_args:
-    type: string
+    type: list
+    separator: ' '
+    list-item:
+      type: string

--- a/typings/codecov/codecov-action/v3/action-types.yml
+++ b/typings/codecov/codecov-action/v3/action-types.yml
@@ -88,3 +88,19 @@ inputs:
     type: string
   swift:
     type: boolean
+  full_report:
+    type: string
+  gcov_executable:
+    type: string
+  network_filter:
+    type: string
+  network_prefix:
+    type: string
+  swift_project:
+    type: string
+  upstream_proxy:
+    type: string
+  working-directory:
+    type: string
+  xtra_args:
+    type: string

--- a/typings/cycjimmy/semantic-release-action/v4/action-types.yml
+++ b/typings/cycjimmy/semantic-release-action/v4/action-types.yml
@@ -24,6 +24,9 @@ inputs:
     type: string
   tag_format:
     type: string
+  repository_url:
+    type: string
+
 outputs:
   new_release_published:
     type: boolean

--- a/typings/docker/metadata-action/v4/action-types.yml
+++ b/typings/docker/metadata-action/v4/action-types.yml
@@ -31,6 +31,8 @@ inputs:
     type: string
   bake-target:
     type: string
+  github-token:
+    type: string
 
 outputs:
   version:

--- a/typings/docker/metadata-action/v5/action-types.yml
+++ b/typings/docker/metadata-action/v5/action-types.yml
@@ -41,6 +41,8 @@ inputs:
     separator: '\n'
     list-item:
       type: string
+  github-token:
+    type: string
 
 outputs:
   version:

--- a/typings/docker/setup-buildx-action/v3/action-types.yml
+++ b/typings/docker/setup-buildx-action/v3/action-types.yml
@@ -32,6 +32,11 @@ inputs:
     type: boolean
   cache-binary:
     type: boolean
+  buildkitd-config:
+    type: string
+  buildkitd-config-inline:
+    type: string
+
 outputs:
   name:
     type: string

--- a/typings/gautamkrishnar/blog-post-workflow/v1/action-types.yml
+++ b/typings/gautamkrishnar/blog-post-workflow/v1/action-types.yml
@@ -77,6 +77,9 @@ inputs:
     type: boolean
   skip_commit:
     type: boolean
+  dummy_commit_message:
+    type: string
+
 outputs:
   results:
     type: string

--- a/typings/github/codeql-action/v2/init/action-types.yml
+++ b/typings/github/codeql-action/v2/init/action-types.yml
@@ -45,6 +45,17 @@ inputs:
     type: string
   trap-caching:
     type: boolean
+  build-mode:
+    type: enum
+    allowed-values:
+      - none
+      - autobuild
+      - manual
+  config:
+    type: string
+  dependency-caching:
+    type: boolean
+
 outputs:
   codeql-path:
     type: string

--- a/typings/google-github-actions/auth/v2/action-types.yml
+++ b/typings/google-github-actions/auth/v2/action-types.yml
@@ -47,8 +47,9 @@ inputs:
     type: boolean
   universe:
     type: string
-  auth_token:
+  request_reason:
     type: string
+
 outputs:
   project_id:
     type: string

--- a/typings/gradle/actions/v3/setup-gradle/action-types.yml
+++ b/typings/gradle/actions/v3/setup-gradle/action-types.yml
@@ -83,7 +83,7 @@ inputs:
   develocity-capture-file-fingerprints:
     type: boolean
   develocity-enforce-url:
-    type: string
+    type: boolean
   develocity-plugin-version:
     type: string
   develocity-ccud-plugin-version:

--- a/typings/gradle/actions/v3/setup-gradle/action-types.yml
+++ b/typings/gradle/actions/v3/setup-gradle/action-types.yml
@@ -66,6 +66,37 @@ inputs:
     type: string
   validate-wrappers:
     type: boolean
+  build-scan-terms-of-use-url:
+    type: string
+  build-scan-terms-of-use-agree:
+    type: string
+  develocity-access-key:
+    type: string
+  develocity-token-expiry:
+    type: integer
+  develocity-injection-enabled:
+    type: boolean
+  develocity-url:
+    type: string
+  develocity-allow-untrusted-server:
+    type: boolean
+  develocity-capture-file-fingerprints:
+    type: boolean
+  develocity-enforce-url:
+    type: string
+  develocity-plugin-version:
+    type: string
+  develocity-ccud-plugin-version:
+    type: string
+  gradle-plugin-repository-url:
+    type: string
+  gradle-plugin-repository-username:
+    type: string
+  gradle-plugin-repository-password:
+    type: string
+  github-token:
+    type: string
+
 outputs:
   build-scan-url:
     type: string

--- a/typings/gradle/gradle-build-action/v2/action-types.yml
+++ b/typings/gradle/gradle-build-action/v2/action-types.yml
@@ -44,6 +44,9 @@ inputs:
     type: boolean
   artifact-retention-days:
     type: integer
+  github-token:
+    type: string
+
 outputs:
   build-scan-url:
     type: string

--- a/typings/gradle/gradle-build-action/v3/action-types.yml
+++ b/typings/gradle/gradle-build-action/v3/action-types.yml
@@ -94,6 +94,9 @@ inputs:
     type: string
   gradle-plugin-repository-password:
     type: string
+  github-token:
+    type: string
+
 outputs:
   build-scan-url:
     type: string

--- a/typings/pbrisbin/setup-tool-action/v2/action-types.yml
+++ b/typings/pbrisbin/setup-tool-action/v2/action-types.yml
@@ -132,6 +132,36 @@ inputs:
   github-token:
     type: string
 
+  url-darwin-arm64:
+    type: string
+
+  subdir-arm64:
+    type: string
+
+  subdir-darwin-arm64:
+    type: string
+
+  os-arm64:
+    type: string
+
+  os-darwin-arm64:
+    type: string
+
+  arch-arm64:
+    type: string
+
+  arch-darwin-arm64:
+    type: string
+
+  ext-arm64:
+    type: string
+
+  ext-darwin-arm64:
+    type string:
+
+  github-token-for-latest:
+    type: string
+
 outputs:
   directory:
     type: string

--- a/typings/repo-sync/pull-request/v2/action-types.yml
+++ b/typings/repo-sync/pull-request/v2/action-types.yml
@@ -35,6 +35,9 @@ inputs:
     type: string
   debug:
     type: boolean
+  destination_repository:
+    type: string
+
 outputs:
   pr_url:
     type: string

--- a/typings/softprops/action-gh-release/v2/action-types.yml
+++ b/typings/softprops/action-gh-release/v2/action-types.yml
@@ -37,6 +37,9 @@ inputs:
     - "true"
     - "false"
     - legacy
+  preserve_order:
+    type: boolean
+
 outputs:
   url:
     type: string

--- a/typings/stefanzweifel/git-auto-commit-action/v4/action-types.yml
+++ b/typings/stefanzweifel/git-auto-commit-action/v4/action-types.yml
@@ -34,6 +34,9 @@ inputs:
     type: boolean
   create_branch:
     type: boolean
+  internal_git_binary:
+    type: string
+
 outputs:
   changes_detected:
     type: boolean

--- a/typings/stefanzweifel/git-auto-commit-action/v5/action-types.yml
+++ b/typings/stefanzweifel/git-auto-commit-action/v5/action-types.yml
@@ -34,6 +34,9 @@ inputs:
     type: boolean
   create_branch:
     type: boolean
+  internal_git_binary:
+    type: string
+
 outputs:
   changes_detected:
     type: boolean

--- a/typings/subosito/flutter-action/v2/action-types.yml
+++ b/typings/subosito/flutter-action/v2/action-types.yml
@@ -23,6 +23,13 @@ inputs:
     - arm64
   dry-run:
     type: boolean
+  flutter-version-file:
+    type: string
+  pub-cache-key:
+    type: string
+  pub-cache-path:
+    type: string
+
 outputs:
   CACHE-PATH:
     type: string


### PR DESCRIPTION
Closes #44.

The check still fails because of a single action having no major version tag/branch. I don't want to add a carveout for it just yet, let's see if there's some traction in https://github.com/DamianReeves/write-file-action/issues/28