### PR TITLE
Read base_ref using library

### DIFF
--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -21,7 +21,6 @@ import io.github.typesafegithub.workflows.domain.triggers.Cron
 import io.github.typesafegithub.workflows.domain.triggers.PullRequest
 import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.domain.triggers.Schedule
-import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
 import it.krzeminski.snakeyaml.engine.kmp.api.Load
 import kotlinx.serialization.json.JsonArray
@@ -81,11 +80,8 @@ workflow(
         uses(action = Checkout())
         run(
             name = "Check for actions",
-            // TODO: replace this workaround once base_ref can be accessed natively:
-            // https://github.com/typesafegithub/github-workflows-kt/issues/1946
-            env = mapOf("base_ref" to expr { github.base_ref })
         ) {
-            validateTypings(github.sha, System.getenv("base_ref").ifEmpty { null })
+            validateTypings(github.sha, github.base_ref)
         }
     }
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,6 @@ jobs:
     - id: 'step-1'
       name: 'Check for actions'
       env:
-        base_ref: '${{ github.base_ref }}'
         GHWKT_GITHUB_CONTEXT_JSON: '${{ toJSON(github) }}'
       run: 'GHWKT_RUN_STEP=''test.yaml:validate_typings:step-1'' ''.github/workflows/test.main.kts'''
   workflows_consistency_check:


### PR DESCRIPTION
Since the library already provides `base_ref`, we can remove the workaround.