### PR TITLE
Add typings under lowercase owner and name

### DIFF
--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -47,6 +47,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.extension
 import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.io.path.name
+import kotlin.io.path.readText
 
 workflow(
     name = "Test",
@@ -146,12 +147,16 @@ private fun validateTypings(sha: String, baseRef: String?) {
             continue
         }
 
-        if (!(Path("typings") / action.owner.lowercase() / action.name.lowercase()).exists()) {
+        println("Checking if ${Path(action.pathToTypings.lowercase())} exists")
+        if (!Path(action.pathToTypings.lowercase()).exists()) {
             // See https://github.com/typesafegithub/github-workflows-kt/issues/2025
             // TODO: enforce only lower-case owner and name once the bindings server is adjusted
             println("\uD83D\uDD34 There's no corresponding typings using lower-case owner and name!")
             shouldFail = true
             continue
+        } else {
+            println("Exists!")
+            println(Path(action.pathToTypings.lowercase()).readText())
         }
 
         val typings = loadTypings(path = action.pathToTypings)

--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -214,8 +214,8 @@ private fun listActionsToValidate(sha: String, baseRef: String?): Stream<ActionC
             println("Validating all typings")
             listAllActionManifestFilesInRepo()
         } else {
-            println("Only validating changed typings")
-            listAffectedActionManifestFiles(sha = sha, baseRef = baseRef)
+            println("Validating all typings")
+            listAllActionManifestFilesInRepo()
         }.map {
             val (_, owner, name, version, pathAndYaml) = it.invariantSeparatorsPathString.split("/", limit = 5)
             val path = if ("/" in pathAndYaml) pathAndYaml.substringBeforeLast("/") else null

--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -147,16 +147,12 @@ private fun validateTypings(sha: String, baseRef: String?) {
             continue
         }
 
-        println("Checking if ${Path(action.pathToTypings.lowercase())} exists")
         if (!Path(action.pathToTypings.lowercase()).exists()) {
             // See https://github.com/typesafegithub/github-workflows-kt/issues/2025
             // TODO: enforce only lower-case owner and name once the bindings server is adjusted
             println("\uD83D\uDD34 There's no corresponding typings using lower-case owner and name!")
             shouldFail = true
             continue
-        } else {
-            println("Exists!")
-            println(Path(action.pathToTypings.lowercase()).readText())
         }
 
         val typings = loadTypings(path = action.pathToTypings)

--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -42,6 +42,8 @@ import java.nio.file.Path
 import java.util.Collections.emptySet
 import java.util.stream.Stream
 import kotlin.io.path.Path
+import kotlin.io.path.div
+import kotlin.io.path.exists
 import kotlin.io.path.extension
 import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.io.path.name
@@ -141,6 +143,14 @@ private fun validateTypings(sha: String, baseRef: String?) {
 
         if (notValidatedActions.any { predicate -> predicate(action) }) {
             println("Skipping...")
+            continue
+        }
+
+        if (!(Path("typings") / action.owner.lowercase() / action.name.lowercase()).exists()) {
+            // See https://github.com/typesafegithub/github-workflows-kt/issues/2025
+            // TODO: enforce only lower-case owner and name once the bindings server is adjusted
+            println("\uD83D\uDD34 There's no corresponding typings using lower-case owner and name!")
+            shouldFail = true
             continue
         }
 


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-workflows-kt/issues/2025.

Allows fixing the issue on the server side. For some time, this repo will have both the current and the lowercase owner and action names. Once the server can search using lowercase versions, we'll host only lowercased variants.