### PR TITLE
Add session-timeout-seconds input for testlens-app/setup-testlens v1

### DIFF
--- a/typings/testlens-app/setup-testlens/v1/action-types.yml
+++ b/typings/testlens-app/setup-testlens/v1/action-types.yml
@@ -6,5 +6,8 @@ inputs:
   instrumentation-version:
     type: string
 
+  session-timeout-seconds:
+    type: integer
+
   write-log-files:
     type: boolean


### PR DESCRIPTION
## Summary

- Add missing `session-timeout-seconds` input to `typings/testlens-app/setup-testlens/v1/action-types.yml`
- Typed as `integer` since it represents a timeout value in seconds

## Evidence

- **Action manifest**: [`action.yml`](https://github.com/testlens-app/setup-testlens/blob/v1/action.yml) defines `session-timeout-seconds` with description `"The timeout (in seconds) to use when waiting for a session to be completed"` — the value is a duration in seconds, which is inherently an integer
- **Usage**: In the [source](https://github.com/testlens-app/setup-testlens/blob/v1/action.yml), the value is used directly as a number via `$SESSION_TIMEOUT_SECONDS` in environment variable assignment and string interpolation, confirming it's numeric
