### PR TITLE
Fail on missing typings for major versions

### DIFF
--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -266,7 +266,8 @@ private fun validateAllMajorVersionsPresent(baseRef: String?) {
     missingMajorVersionsForAction.forEach { (actionCoords, versions) ->
         println("- $actionCoords: $versions")
     }
-    // TODO: fail once all missing major versions are added
+
+    throw RuntimeException("Missing major versions found!")
 }
 
 private fun listActionVersionsToValidate(sha: String, baseRef: String?): Stream<ActionCoords> =


### PR DESCRIPTION
Part of https://github.com/typesafegithub/github-actions-typing-catalog/issues/106.

Now that all recent major versions are added, we can start failing on missing ones.