### PR TITLE
Add typings for dawidd6/action-get-tag@v1

### DIFF
--- a/typings/dawidd6/action-get-tag/metadata.yml
+++ b/typings/dawidd6/action-get-tag/metadata.yml
@@ -1,0 +1,2 @@
+"versionsWithTypings":
+- "v1"

--- a/typings/dawidd6/action-get-tag/v1/action-types.yml
+++ b/typings/dawidd6/action-get-tag/v1/action-types.yml
@@ -1,0 +1,7 @@
+# See https://github.com/typesafegithub/github-actions-typing
+inputs:
+  strip_v:
+    type: boolean
+outputs:
+  tag:
+    type: string


### PR DESCRIPTION
This PR adds type definitions for [dawidd6/action-get-tag](https://github.com/dawidd6/action-get-tag).

Typings for v1 are included.