### PR TITLE
Restore newest Kotlin and fix usage of `kotlinc`

### DIFF
--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -74,7 +74,7 @@ workflow(
             find -name *.main.kts -print0 | while read -d ${'$'}'\0' file
             do
                 echo "Compiling ${'$'}file..."
-                kotlinc -Xallow-any-scripts-in-source-roots -Xuse-fir-lt=false "${'$'}file"
+                kotlinc -script -Xallow-any-scripts-in-source-roots -Xuse-fir-lt=false "${'$'}file"
             done
             """.trimIndent()
         )

--- a/.github/workflows/test.main.kts
+++ b/.github/workflows/test.main.kts
@@ -4,7 +4,6 @@
 @file:DependsOn("it.krzeminski:snakeyaml-engine-kmp-jvm:4.0.1")
 @file:DependsOn("io.github.optimumcode:json-schema-validator-jvm:0.5.5")
 @file:DependsOn("com.github.sya-ri:kgit:1.2.0")
-@file:DependsOn("fwilhe2:setup-kotlin:v1")
 
 @file:Repository("https://bindings.krzeminski.it")
 @file:DependsOn("actions:checkout:v6")
@@ -16,7 +15,6 @@ import io.github.optimumcode.json.schema.ErrorCollector
 import io.github.optimumcode.json.schema.JsonSchema
 import io.github.optimumcode.json.schema.ValidationError
 import io.github.typesafegithub.workflows.actions.actions.Checkout
-import io.github.typesafegithub.workflows.actions.fwilhe2.SetupKotlin
 import io.github.typesafegithub.workflows.annotations.ExperimentalKotlinLogicStep
 import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
 import io.github.typesafegithub.workflows.domain.triggers.Cron
@@ -71,15 +69,6 @@ workflow(
         runsOn = UbuntuLatest,
     ) {
         uses(action = Checkout())
-        uses(
-            name = "Downgrade Kotlin",
-            action = SetupKotlin(
-                // One version before 2.4.0 that contains a bug leading to this failure:
-                //   exception: java.lang.ClassNotFoundException: kotlin.script.experimental.dependencies.Repository
-                // This downgrade is meant to be a temporary workaround.
-                version = "2.3.21",
-            ),
-        )
         run(
             command = """
             find -name *.main.kts -print0 | while read -d ${'$'}'\0' file

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
         find -name *.main.kts -print0 | while read -d $'\0' file
         do
             echo "Compiling $file..."
-            kotlinc -Xallow-any-scripts-in-source-roots -Xuse-fir-lt=false "$file"
+            kotlinc -script -Xallow-any-scripts-in-source-roots -Xuse-fir-lt=false "$file"
         done
   validate_typings:
     name: 'Validate typings'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,11 +33,6 @@ jobs:
     - id: 'step-0'
       uses: 'actions/checkout@v6'
     - id: 'step-1'
-      name: 'Downgrade Kotlin'
-      uses: 'fwilhe2/setup-kotlin@v1'
-      with:
-        version: '2.3.21'
-    - id: 'step-2'
       run: |-
         find -name *.main.kts -print0 | while read -d $'\0' file
         do


### PR DESCRIPTION
See https://kotlinlang.slack.com/archives/C0BT46EL8/p1781706828156549?thread_ts=1781345521.439599&cid=C0BT46EL8

> Well, in your example you're compiling a main-kts script as a regular source without specifying main-kts jar as a dependency, so the annotation is not in the dependencies.
You either need to add the jar to -cp or use -script. The latter "magically" adds definition jar into classpath.
Have you seen it working before?